### PR TITLE
fixed seconds =>minutes, xccdf_org.cisecurity.benchmarks_rule_1.2.3_L…

### DIFF
--- a/controls/section_1.rb
+++ b/controls/section_1.rb
@@ -167,6 +167,6 @@ control "xccdf_org.cisecurity.benchmarks_rule_1.2.3_L1_Ensure_Reset_account_lock
   "
   impact 1.0
   describe security_policy do
-    its("ResetLockoutCount") { should be >= 900 }
+    its("ResetLockoutCount") { should be >= 15 }
   end
 end


### PR DESCRIPTION
…1_Ensure_Reset_account_lockout_counter_after_is_set_to_15_or_more_minutes